### PR TITLE
feat(build): stabilize Maven build and test compilation setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -16,6 +16,8 @@
 	<properties>
 		<java.version>20</java.version>
 		<serenity.version>4.1.14</serenity.version>
+		<cucumber.version>7.14.0</cucumber.version>
+		<lombok.version>1.18.32</lombok.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -53,6 +55,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -83,10 +86,35 @@
 			<artifactId>junit-platform-suite</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-junit-platform-engine</artifactId>
+			<version>${cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-spring</artifactId>
+			<version>${cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -116,7 +144,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install</arguments>
+							<arguments>ci</arguments>
                         </configuration>
                     </execution>
                     <execution>

--- a/backend/src/main/java/com/computech/ctui/util/WebUtils.java
+++ b/backend/src/main/java/com/computech/ctui/util/WebUtils.java
@@ -3,6 +3,7 @@ package com.computech.ctui.util;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotNull;
 import lombok.SneakyThrows;
+
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestAttributes;


### PR DESCRIPTION
This pull request updates the project's Maven configuration to improve dependency management and testing support. The main changes include adding and updating dependencies for Cucumber and Lombok, configuring annotation processing for Lombok, and optimizing the frontend build process.

**Dependency and build configuration updates:**

* Added properties for `cucumber.version` (7.14.0) and `lombok.version` (1.18.32) to centralize version management in `pom.xml`.
* Set the Lombok dependency to use the new version property for consistency and maintainability.
* Added Cucumber dependencies for JUnit Platform integration (`cucumber-junit-platform-engine`) and Spring support (`cucumber-spring`) to enable BDD testing with Cucumber.
* Configured the `maven-compiler-plugin` to include Lombok's annotation processor, ensuring proper code generation during compilation.

**Build process improvement:**

* Changed the frontend Maven plugin's npm install command from `install` to `ci` for faster, more reliable builds using the lockfile.

**Minor code style update:**

* Added a blank line in `WebUtils.java` for improved code readability.